### PR TITLE
Add npm-dependencies group to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
     ignore:
       # ignore all GitHub linguist patch updates
       - dependency-name: "*"


### PR DESCRIPTION
This pull request introduces a grouping configuration for npm dependencies in the Dependabot setup. This change helps organize dependency updates more efficiently.

Dependabot configuration improvements:

* Added a `groups` section under `updates` in `.github/dependabot.yml` to group all npm dependencies together using the `npm-dependencies` group with the pattern `"*"`.